### PR TITLE
fix(dependencies): update Polars dependency to include runtime features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 readme = "README.md"
 license = {file = "LICENSE"}
 dependencies = [
-    "polars>=1.39.2",
+    "polars[rt64]>=1.39.2",
     "pyarrow>=14.0.0",
     "pyyaml==6.0.2",
     "pydantic>=2.11.7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Data processing
-polars>=1.39.2
+polars[rt64]>=1.39.2
 pyarrow>=14.0.0
 # YAML
 pyyaml==6.0.2


### PR DESCRIPTION
polars[rt64] 

- Row indices are 64bit integers 
- Max ~18 quintillion rows (virtually unlimited)
- Tiny memory overhead per row(4 extra bytes)
- Required when any single parquet/dataframe exceeds 4.3B rows(e.g. test file for 700 years)

Advance optimization of our library in future: 

1. Scan input simulation table 
2. If table exceeds 32bit limit use polars[rt64] 
3. In else case use polars 32 bit in order to skip 4 extra bytes per row(memory overhead)