### PR TITLE
(PR1) chore: align dependency pinning policy across all repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pyarrow>=14.0.0",
     "pyyaml>=6.0.2",
     "pydantic>=2.11.7",
-    "gemspy==0.0.4",
+    "gemspy==0.1.0",
 ]
 authors = [
     { name = "Antoine Oustry" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ license = {file = "LICENSE"}
 dependencies = [
     "polars[rt64]>=1.39.2",
     "pyarrow>=14.0.0",
-    "pyyaml==6.0.2",
+    "pyyaml>=6.0.2",
     "pydantic>=2.11.7",
-    "gemspy>=0.0.4",
+    "gemspy==0.0.4",
 ]
 authors = [
     { name = "Antoine Oustry" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pyarrow>=14.0.0",
     "pyyaml>=6.0.2",
     "pydantic>=2.11.7",
-    "gemspy==0.1.0",
+    "gemspy==0.0.4",
 ]
 authors = [
     { name = "Antoine Oustry" },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
 # Testing
-pytest==7.0.1
-pytest-xdist==3.8.0
+pytest>=7.0.1
+pytest-xdist>=3.8.0
 # Code quality
-mypy~=1.15.0
+mypy>=1.15.0
 types-PyYAML>=6.0.0
-ruff~=0.9.6
-pre-commit~=4.1.0
+ruff>=0.9.6
+pre-commit>=4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyyaml>=6.0.2
 # Pydantic
 pydantic>=2.11.7
 # gemspy
-gemspy==0.1.0
+gemspy==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyyaml>=6.0.2
 # Pydantic
 pydantic>=2.11.7
 # gemspy
-gemspy==0.0.4
+gemspy==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 polars[rt64]>=1.39.2
 pyarrow>=14.0.0
 # YAML
-pyyaml==6.0.2
+pyyaml>=6.0.2
 # Pydantic
 pydantic>=2.11.7
 # gemspy


### PR DESCRIPTION
## Process CHORE - Dependencies Policy Pinning Allignment

### Aligns dependency pinning across the GEMS ecosystem with an agreed policy:

Third-party dependencies → >= (flexible lower bound, allows patch/minor upgrades without manual bumps)
Specific/internal dependencies (antares-craft, gemspy, pypsa) → == (exact pin, ensures coordinated releases between GEMS components)

## Description

Two changes in:

 **pyproject.toml:**

pyyaml==6.0.2 → >=6.0.2 — relaxed to >= (third-party)
gemspy>=0.0.4 → ==0.0.4 — tightened to exact pin (internal dependency)

**requirements.txt:** 

pyyaml==6.0.2 → >=6.0.2

**requirements-dev.txt:** pytest, pytest-xdist, mypy, ruff, pre-commit — all ==/~= → >=


## Checklist

- [x] Github Workflow Pass
